### PR TITLE
Auth fixes and better concurrency for game rooms

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,4 +47,4 @@ jobs:
       with:
         subject-name: ${{env.REGISTRY}}/${{env.IMAGE_NAME}}
         subject-digest: ${{steps.push.outputs.digest}}
-        push-to-registry: true
+        push-to-registry: false

--- a/handler/cookie.go
+++ b/handler/cookie.go
@@ -4,13 +4,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/kodekulture/wordle-server/internal/config"
 	"github.com/lordvidex/x/auth"
 )
-
-func isProd() bool {
-	return config.Get("ENV") == "prod"
-}
 
 const (
 	accessTokenTTL  = 1 * time.Hour        // 1 hr
@@ -22,7 +17,7 @@ func newAccessCookie(token auth.Token) http.Cookie {
 		Name:     accessTokenKey,
 		Value:    string(token),
 		Expires:  time.Now().Add(accessTokenTTL),
-		Secure:   isProd(), // enable development usage
+		Secure:   true,
 		HttpOnly: true,
 		SameSite: http.SameSiteNoneMode,
 	}
@@ -33,7 +28,7 @@ func newRefreshCookie(token auth.Token) http.Cookie {
 		Name:     refreshTokenKey,
 		Value:    string(token),
 		Expires:  time.Now().Add(refreshTokenTTL),
-		Secure:   isProd(), // enable development usage
+		Secure:   true,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -24,10 +24,10 @@ import (
 
 var (
 	kors = cors.New(cors.Options{
-		AllowedOrigins: []string{"http://localhost:3000"},
-		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders: []string{"Accept", "Authorization", "Content-Type"},
-		MaxAge:         300,
+		AllowedOrigins:   []string{"http://localhost:3000"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
+		AllowCredentials: true,
 	})
 	// Create upgrade websocket connection
 	upgrader = websocket.Upgrader{

--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	accessTokenKey  = "__Secure-access-token"
-	refreshTokenKey = "__Secure-refresh-token"
+	accessTokenKey  = "X-Access-Token"
+	refreshTokenKey = "X-Refresh-Token"
 )
 
 type (
@@ -62,6 +62,7 @@ func (h *Handler) sessionMiddleware(next http.Handler) http.Handler {
 				resp.Error(w, err)
 				return
 			}
+			http.SetCookie(w, accessCk) // set recently refreshed cookie
 			isDBPlayer = true
 		}
 

--- a/repository/postgres/player.go
+++ b/repository/postgres/player.go
@@ -43,9 +43,10 @@ func (r *PlayerRepo) GetByUsername(ctx context.Context, username string) (*game.
 		return nil, err
 	}
 	return &game.Player{
-		ID:       int(player.ID),
-		Username: player.Username,
-		Password: player.Password,
+		ID:        int(player.ID),
+		Username:  player.Username,
+		Password:  player.Password,
+		SessionTs: player.SessionTs.Int64,
 	}, nil
 }
 

--- a/service/hub_service.go
+++ b/service/hub_service.go
@@ -1,10 +1,21 @@
 package service
 
 import (
+	"context"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/kodekulture/wordle-server/game"
+)
+
+const (
+	// RoomDuration is the maximum time for a game, room is deleted and game data is wiped if
+	// game is not played during this time.
+	RoomDuration = time.Hour
+	// EmptyRoomDuration is the maximum time a game is left without players. It is shorter than RoomDuration
+	// because Room is probably not in use anymore and contains no data.
+	EmptyRoomDuration = time.Minute * 15
 )
 
 type hub struct {
@@ -13,11 +24,14 @@ type hub struct {
 }
 
 // NewStorage returns a new Storage.
-func newHub(r map[uuid.UUID]*game.Room) *hub {
+func newHub(ctx context.Context, r map[uuid.UUID]*game.Room) *hub {
 	if r == nil {
 		r = make(map[uuid.UUID]*game.Room)
 	}
-	return &hub{rooms: r}
+	h := hub{rooms: r}
+	go h.gc(ctx)
+
+	return &h
 }
 
 // GetRoom returns the room with the given id and a bool indicating whether the room was found.
@@ -40,4 +54,71 @@ func (s *hub) DeleteRoom(id uuid.UUID) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.rooms, id)
+}
+
+func (s *hub) gc(ctx context.Context) {
+	ticker := time.NewTicker(15 * time.Minute)
+	defer ticker.Stop()
+
+	isMarkPhase := true
+	garbage := make([]*game.Room, 0)
+
+	mark := func() {
+		garbage = nil
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+
+		for _, r := range s.rooms {
+			g := r.Game()
+			if g == nil {
+				garbage = append(garbage, r)
+				continue
+			}
+
+			if time.Since(g.CreatedAt) >= RoomDuration {
+				garbage = append(garbage, r)
+				continue
+			}
+
+			if time.Since(g.CreatedAt) >= EmptyRoomDuration && len(g.Sessions) == 0 {
+				garbage = append(garbage, r)
+				continue
+			}
+		}
+	}
+
+	sweep := func() {
+		// 1. fast remove from rooms
+		s.mu.Lock()
+		for _, r := range garbage {
+			v, _ := uuid.Parse(r.ID())
+			delete(s.rooms, v)
+		}
+		s.mu.Unlock()
+
+		// 2. cleanup later
+		for _, r := range garbage {
+			if r.IsClosed() {
+				continue
+			}
+			r.Close()
+		}
+		garbage = nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if isMarkPhase {
+				mark()
+			} else {
+				// sweep phase
+				sweep()
+			}
+
+			isMarkPhase = !isMarkPhase
+		}
+	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -97,7 +97,9 @@ func New(appCtx context.Context, gr repository.Game, pr repository.Player, cr re
 	if err != nil {
 		return nil, fmt.Errorf("failed to load hub: %s", err.Error())
 	}
-	s.hub = newHub(data)
+
+	log.Warn().Msgf("loaded hub with %d rooms", len(data))
+	s.hub = newHub(appCtx, data)
 	go s.drop(appCtx)
 	return s, nil
 }


### PR DESCRIPTION
- fix: Changed Cookie names because __Secure is restrictive
- fix: Add AllowCredentials to cors
- fix: Cleanup idle room connections
- fix: add set-cookie for access cookie after refresh
- fix: include sessionTs when fetching user from db
- fix: prevent panic when closing room by niling channel instead of closing
- chore: Print number of rooms in hub after loading into memory.